### PR TITLE
feat: make uniffi optional behind the ffi feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,6 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "uniffi_bindgen",
- "uniffi_build",
  "uniffi_core",
  "uniffi_macros",
 ]
@@ -738,17 +737,6 @@ dependencies = [
  "uniffi_meta",
  "uniffi_testing",
  "uniffi_udl",
-]
-
-[[package]]
-name = "uniffi_build"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
-dependencies = [
- "anyhow",
- "camino",
- "uniffi_bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,12 @@ path = "src/bin/uniffi_bindgen.rs"
 required-features = ["cli"]
 
 [features]
-default = []
-cli = ["uniffi/cli"]
+# `ffi` is on by default so the mobile bindings keep building unchanged.
+# Rust-only consumers should set `default-features = false` to avoid pulling
+# in uniffi and its bindgen chain (goblin, weedle2, cargo_metadata, ...).
+default = ["ffi"]
+ffi = ["dep:uniffi"]
+cli = ["ffi", "uniffi/cli"]
 
 [dependencies]
 camino = { version = "1.1", features = ["serde1"] }
@@ -26,10 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
 thiserror = "2"
-uniffi = "0.28"
-
-[build-dependencies]
-uniffi = { version = "0.28", features = ["build"] }
+uniffi = { version = "0.28", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,18 +28,22 @@
 //!
 //! ## UniFFI Support
 //!
-//! This library includes UniFFI bindings for use on iOS and Android.
-//! The FFI module provides simplified, FFI-safe types and functions.
+//! This library includes UniFFI bindings for use on iOS and Android, behind the
+//! `ffi` feature. It is enabled by default, so the mobile bindings build
+//! unchanged; the `ffi` module provides simplified, FFI-safe types and functions.
 //!
-//! See the [`ffi`] module for FFI-specific types and functions.
+//! Rust-only consumers should depend on this crate with `default-features = false`
+//! to avoid compiling uniffi and its bindgen chain.
 
 // UniFFI scaffolding - must be at crate root
+#[cfg(feature = "ffi")]
 uniffi::setup_scaffolding!();
 
 /// Recipe fetching utilities for loading recipes by name.
 pub mod fetcher;
 
 /// UniFFI bindings for cross-platform support (iOS, Android).
+#[cfg(feature = "ffi")]
 pub mod ffi;
 
 /// Menu discovery by date (sections containing a date string).


### PR DESCRIPTION
Part of the dependency reduction for cooklang/cookcli#366 ("Dependency Hell").

## Problem

`uniffi` is an unconditional dependency of `cooklang-find`. It exists to generate the iOS/Android bindings — but **every Rust consumer compiles it anyway**, along with its bindgen chain: `uniffi_bindgen`, `goblin`, `weedle2`, `cargo_metadata`, `scroll`, `bincode`, `basic-toml`, `fs-err`, ...

For CookCLI that is ~22 crates of pure dead weight, and `uniffi_bindgen` is a heavyweight build-time dependency that must compile before anything else in the graph.

## Change

- `uniffi` becomes `optional = true`, gated behind a new `ffi` feature.
- **`ffi` is ON by default**, so the mobile bindings (`cooklang-android`, `cooklang-kotlin`) keep building with no change on their side. Rust-only consumers opt out with `default-features = false`.
- `cli` now implies `ffi`, since the `uniffi-bindgen` binary needs it.
- Dropped the `[build-dependencies] uniffi` entry — the crate has **no `build.rs`**, so it was never used.

I chose default-on rather than the arguably cleaner default-off specifically to avoid silently breaking the mobile builds. Happy to flip it if you would rather have the FFI be opt-in.

## Verification

| | build | tests | clippy | rustdoc |
|---|---|---|---|---|
| default (`ffi` on) | ✅ | ✅ 100 passed | clean | 0 warnings |
| `--no-default-features` | ✅ | ✅ 94 passed | clean | 0 warnings |

`cargo fmt --check` clean.

## Follow-on

This only removes uniffi from CookCLI's graph in combination with:
1. cooklang/cooklang-reports#8 — moves `cooklang-reports` onto `cooklang-find` 0.6 (it is the last crate on the 0.5 line, so CookCLI currently compiles `cooklang-find` **twice**)
2. a CookCLI bump to `cooklang-reports` 0.5.x + `default-features = false` on both

With all three, CookCLI goes 418 → 396 crates and `uniffi` leaves the graph entirely.