### PR TITLE
ci: publish to crates.io on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,20 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # Catches packaging problems (missing files, bad metadata) on a PR,
+      # rather than when a release tries to publish to crates.io.
+      - name: Check the crate packages cleanly
+        run: cargo publish --dry-run
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,3 +608,47 @@ jobs:
         run: |
           gradle wrapper --gradle-version 8.5
           ./gradlew publish --no-daemon
+
+  # Publish the Rust crate to crates.io
+  #
+  # This was missing: the workflow tagged a version and cut a GitHub release,
+  # but never reached crates.io - so downstream crates, which resolve from the
+  # registry, could not see the release at all. See cooklang/cookcli#366.
+  #
+  # Runs after create-release so it publishes the same commit that was tagged
+  # (create-release depends on prepare-release, which pushes the version bump).
+  publish-rust:
+    name: Publish to crates.io
+    needs: [prepare-release, create-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required by crates-io-auth-action for OIDC trusted publishing.
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify the tagged version is what we are publishing
+        run: |
+          MANIFEST_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          EXPECTED="${{ needs.prepare-release.outputs.version }}"
+          if [ "$MANIFEST_VERSION" != "$EXPECTED" ]; then
+            echo "::error::Cargo.toml is at ${MANIFEST_VERSION} but releasing ${EXPECTED}"
+            exit 1
+          fi
+          echo "Publishing ${MANIFEST_VERSION}"
+
+      - name: Authenticate to crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish


### PR DESCRIPTION
The release workflow tagged a version, built the iOS/Android bindings and cut a GitHub release — but **never published to crates.io**.

Downstream crates resolve from the registry, so a "release" was invisible to them. That is exactly what stalled the dependency chain in cooklang/cookcli#366: `v0.6.1` was tagged and released on GitHub, `cooklang-reports` and CookCLI still could not see it, and it had to be `cargo publish`ed by hand.

## Changes

**`release.yml`** — new `publish-rust` job. Runs after `create-release` (so it publishes the same commit that got tagged, including the version bump `prepare-release` pushes), asserts `Cargo.toml` matches the version being released before uploading, then publishes.

**`ci.yml`** — new `package` job running `cargo publish --dry-run` on every push/PR, so packaging breakage surfaces on a PR rather than mid-release.

## Auth — one-time setup needed

Uses **OIDC trusted publishing** via `rust-lang/crates-io-auth-action@v1`, matching `cooklang-rs` and CookCLI, so no `CARGO_REGISTRY_TOKEN` secret. It does need a Trusted Publisher registered for this crate first:

> crates.io → `cooklang-find` → Settings → Trusted Publishing → add
> repository `cooklang/cooklang-find`, workflow `release.yml`

Until then the publish job fails on auth — but note everything before it (bindings, tag, GitHub release) still succeeds, which is precisely the failure mode that bit us: a release that looks successful but never reaches the registry. Worth configuring before the next release.

## Verification
- `cargo publish --dry-run` — packages cleanly (`Uploading cooklang-find v0.6.1`)
- Both workflow files validate as YAML; job graph is `prepare-release → build-ios/build-android → update-package-swift → create-release → publish-android, publish-rust`

Refs cooklang/cookcli#366
